### PR TITLE
Add pat and HttpRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of benchmarks for popular Go web frameworks.
 *  [Martini](https://github.com/codegangsta/martini)
 *  [Tiger Tonic](https://github.com/rcrowley/go-tigertonic)
 *  [Traffic](https://github.com/pilu/traffic)
+*  [pat](https://github.com/bmizerany/pat)
 
 # Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A collection of benchmarks for popular Go web frameworks.
 
 *  [gocraft/web](https://github.com/gocraft/web)
 *  [gorilla/mux](https://github.com/gorilla/mux)
+*  [HttpRouter](https://github.com/julienschmidt/httprouter)
 *  [Martini](https://github.com/codegangsta/martini)
 *  [Tiger Tonic](https://github.com/rcrowley/go-tigertonic)
 *  [Traffic](https://github.com/pilu/traffic)

--- a/mux_bench_test.go
+++ b/mux_bench_test.go
@@ -159,9 +159,9 @@ func gorillaMuxRouterFor(namespaces []string, resources []string) http.Handler {
 		for _, res := range resources {
 			subrouter.HandleFunc("/"+res, helloHandler).Methods("GET")
 			subrouter.HandleFunc("/"+res, helloHandler).Methods("POST")
-			subrouter.HandleFunc("/"+res+"/:id", helloHandler).Methods("GET")
-			subrouter.HandleFunc("/"+res+"/:id", helloHandler).Methods("PUT")
-			subrouter.HandleFunc("/"+res+"/:id", helloHandler).Methods("DELETE")
+			subrouter.HandleFunc("/"+res+"/{id}", helloHandler).Methods("GET")
+			subrouter.HandleFunc("/"+res+"/{id}", helloHandler).Methods("PUT")
+			subrouter.HandleFunc("/"+res+"/{id}", helloHandler).Methods("DELETE")
 		}
 	}
 	return router


### PR DESCRIPTION
This PR adds two new packages:
- [pat](https://github.com/bmizerany/pat) by Keith Rarick and Blake Mizerany
- My own very new package [HttpRouter](https://github.com/julienschmidt/httprouter)

Moreover I'd suggest to also measure heap allocs (`-benchmem` param). And a note for the Windows users, that `go test -bench=. -benchmem 2> nul` works for them, would be nice.

Here is the slightly reformatted output:

```
BenchmarkGocraftWeb_Simple             1000000      2288 ns/op       472 B/op    16 allocs/op
BenchmarkGocraftWeb_Route15             500000      3530 ns/op       859 B/op    20 allocs/op
BenchmarkGocraftWeb_Route75             500000      3536 ns/op       859 B/op    20 allocs/op
BenchmarkGocraftWeb_Route150            500000      3518 ns/op       859 B/op    20 allocs/op
BenchmarkGocraftWeb_Route300            500000      3530 ns/op       859 B/op    20 allocs/op
BenchmarkGocraftWeb_Route3000           500000      3864 ns/op       859 B/op    20 allocs/op
BenchmarkGocraftWeb_Middleware          200000      8350 ns/op       914 B/op    28 allocs/op
BenchmarkGocraftWeb_Composite           200000      8825 ns/op      1316 B/op    29 allocs/op

BenchmarkGorillaMux_Simple              500000      3058 ns/op       479 B/op     6 allocs/op
BenchmarkGorillaMux_Route15             200000     14805 ns/op       266 B/op     5 allocs/op
BenchmarkGorillaMux_Route75             100000     23321 ns/op       268 B/op     5 allocs/op
BenchmarkGorillaMux_Route150             50000     34581 ns/op       274 B/op     5 allocs/op
BenchmarkGorillaMux_Route300             50000     57323 ns/op       282 B/op     5 allocs/op
BenchmarkGorillaMux_Route3000             5000    488027 ns/op      1886 B/op    11 allocs/op

BenchmarkCodegangstaMartini_Simple      500000      6924 ns/op      1057 B/op    17 allocs/op
BenchmarkCodegangstaMartini_Route15     200000     13110 ns/op      1251 B/op    18 allocs/op
BenchmarkCodegangstaMartini_Route75     100000     16230 ns/op      1252 B/op    18 allocs/op
BenchmarkCodegangstaMartini_Route150    100000     19871 ns/op      1255 B/op    18 allocs/op
BenchmarkCodegangstaMartini_Route300    100000     27111 ns/op      1260 B/op    18 allocs/op
BenchmarkCodegangstaMartini_Route3000    10000    155908 ns/op      2163 B/op    24 allocs/op
BenchmarkCodegangstaMartini_Middleware  100000     16120 ns/op      1818 B/op    28 allocs/op
BenchmarkCodegangstaMartini_Composite    50000     31821 ns/op      2220 B/op    30 allocs/op

BenchmarkRcrowleyTigerTonic_Simple     5000000       318 ns/op        47 B/op     1 allocs/op
BenchmarkRcrowleyTigerTonic_Route15     500000     41342 ns/op    222054 B/op    14 allocs/op
BenchmarkRcrowleyTigerTonic_Route75     500000     11496 ns/op     45968 B/op    14 allocs/op
BenchmarkRcrowleyTigerTonic_Route150    500000      7728 ns/op     23844 B/op    14 allocs/op
BenchmarkRcrowleyTigerTonic_Route300    500000      5856 ns/op     12592 B/op    14 allocs/op
BenchmarkRcrowleyTigerTonic_Route3000   500000      3772 ns/op      2064 B/op    14 allocs/op

BenchmarkPiluTraffic_Simple             500000      2958 ns/op       834 B/op    15 allocs/op
BenchmarkPiluTraffic_Route15            200000      8910 ns/op      1784 B/op    22 allocs/op
BenchmarkPiluTraffic_Route75            100000     16710 ns/op      4250 B/op    40 allocs/op
BenchmarkPiluTraffic_Route150           100000     26691 ns/op      7325 B/op    61 allocs/op
BenchmarkPiluTraffic_Route300            50000     46902 ns/op     13474 B/op   104 allocs/op
BenchmarkPiluTraffic_Route3000           10000    480127 ns/op    116791 B/op   823 allocs/op
BenchmarkPiluTraffic_Middleware         500000      3104 ns/op       833 B/op    15 allocs/op
BenchmarkPiluTraffic_Composite          100000     24891 ns/op      7799 B/op    63 allocs/op

BenchmarkPat_Simple                    2000000       916 ns/op       211 B/op     5 allocs/op
BenchmarkPat_Route15                    500000     34303 ns/op    111690 B/op    10 allocs/op
BenchmarkPat_Route75                    500000     10290 ns/op     23913 B/op    18 allocs/op
BenchmarkPat_Route150                   500000      8528 ns/op     13183 B/op    29 allocs/op
BenchmarkPat_Route300                   200000      9050 ns/op      4862 B/op    50 allocs/op
BenchmarkPat_Route3000                   50000     71944 ns/op     21018 B/op   426 allocs/op

BenchmarkHttpRouter_Simple            10000000       162 ns/op        14 B/op     0 allocs/op
BenchmarkHttpRouter_Route15            5000000       442 ns/op       220 B/op     1 allocs/op
BenchmarkHttpRouter_Route75            5000000       470 ns/op       220 B/op     1 allocs/op
BenchmarkHttpRouter_Route150           5000000       468 ns/op       220 B/op     1 allocs/op
BenchmarkHttpRouter_Route300           5000000       484 ns/op       220 B/op     1 allocs/op
BenchmarkHttpRouter_Route3000          5000000       528 ns/op       220 B/op     1 allocs/op

ok      ../golang-mux-benchmark    160.427s
```
