### PR TITLE
add httptreemux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of benchmarks for popular Go web frameworks.
 *  [Martini](https://github.com/codegangsta/martini)
 *  [Tiger Tonic](https://github.com/rcrowley/go-tigertonic)
 *  [Traffic](https://github.com/pilu/traffic)
+*  [httptreemux](https://github.com/dimfeld/httptreemux)
 
 # Benchmarks
 


### PR DESCRIPTION
Added support [httptreemux](https://github.com/dimfeld/httptreemux):

```
$ go test -bench=. -benchmem 2>/dev/null
goos: darwin
goarch: amd64
pkg: github.com/marconi/golang-mux-benchmark
BenchmarkGocraftWeb_Simple-4               	 3000000	       491 ns/op	     308 B/op	       6 allocs/op
BenchmarkGocraftWeb_Route15-4              	 1000000	      1931 ns/op	     575 B/op	       7 allocs/op
BenchmarkGocraftWeb_Route75-4              	 1000000	      2117 ns/op	     575 B/op	       7 allocs/op
BenchmarkGocraftWeb_Route150-4             	 1000000	      2222 ns/op	     575 B/op	       7 allocs/op
BenchmarkGocraftWeb_Route300-4             	 1000000	      2048 ns/op	     575 B/op	       7 allocs/op
BenchmarkGocraftWeb_Route3000-4            	  500000	      2720 ns/op	     575 B/op	       7 allocs/op
BenchmarkGocraftWeb_Middleware-4           	 2000000	       897 ns/op	     434 B/op	       8 allocs/op
BenchmarkGocraftWeb_Composite-4            	  500000	      3488 ns/op	     683 B/op	       8 allocs/op
BenchmarkGorillaMux_Simple-4               	 2000000	       867 ns/op	     994 B/op	       9 allocs/op
BenchmarkGorillaMux_Route15-4              	  500000	      2500 ns/op	    1193 B/op	      10 allocs/op
BenchmarkGorillaMux_Route75-4              	  300000	      4662 ns/op	    1190 B/op	      10 allocs/op
BenchmarkGorillaMux_Route150-4             	  200000	      7343 ns/op	    1188 B/op	      10 allocs/op
BenchmarkGorillaMux_Route300-4             	  100000	     14347 ns/op	    1194 B/op	      10 allocs/op
BenchmarkGorillaMux_Route3000-4            	   10000	    121817 ns/op	    1965 B/op	      12 allocs/op
BenchmarkCodegangstaMartini_Simple-4       	  300000	      3869 ns/op	     831 B/op	      10 allocs/op
BenchmarkCodegangstaMartini_Route15-4      	  300000	      4867 ns/op	    1019 B/op	      10 allocs/op
BenchmarkCodegangstaMartini_Route75-4      	  200000	      6153 ns/op	    1028 B/op	      10 allocs/op
BenchmarkCodegangstaMartini_Route150-4     	  200000	      7788 ns/op	    1042 B/op	      10 allocs/op
BenchmarkCodegangstaMartini_Route300-4     	  100000	     11112 ns/op	    1131 B/op	      10 allocs/op
BenchmarkCodegangstaMartini_Route3000-4    	   20000	    117156 ns/op	    6947 B/op	      12 allocs/op
BenchmarkCodegangstaMartini_Middleware-4   	  100000	     15124 ns/op	    1308 B/op	      16 allocs/op
BenchmarkCodegangstaMartini_Composite-4    	  100000	     19231 ns/op	    1738 B/op	      17 allocs/op
BenchmarkPiluTraffic_Simple-4              	 1000000	      1197 ns/op	     682 B/op	      13 allocs/op
BenchmarkPiluTraffic_Route15-4             	 1000000	      1919 ns/op	    1234 B/op	      18 allocs/op
BenchmarkPiluTraffic_Route75-4             	  500000	      3202 ns/op	    1638 B/op	      26 allocs/op
BenchmarkPiluTraffic_Route150-4            	  300000	      4881 ns/op	    2140 B/op	      37 allocs/op
BenchmarkPiluTraffic_Route300-4            	  200000	      8152 ns/op	    3146 B/op	      58 allocs/op
BenchmarkPiluTraffic_Route3000-4           	   20000	     84404 ns/op	   20999 B/op	     423 allocs/op
BenchmarkPiluTraffic_Middleware-4          	 1000000	      1091 ns/op	     682 B/op	      13 allocs/op
BenchmarkPiluTraffic_Composite-4           	  300000	      4948 ns/op	    2527 B/op	      39 allocs/op
BenchmarkHttpTreeMux_Simple-4              	20000000	       106 ns/op	      14 B/op	       0 allocs/op
BenchmarkHttpTreeMux_Route15-4             	 3000000	       446 ns/op	     482 B/op	       3 allocs/op
BenchmarkHttpTreeMux_Route75-4             	 3000000	       453 ns/op	     482 B/op	       3 allocs/op
BenchmarkHttpTreeMux_Route150-4            	 3000000	       455 ns/op	     482 B/op	       3 allocs/op
BenchmarkHttpTreeMux_Route300-4            	 3000000	       468 ns/op	     482 B/op	       3 allocs/op
BenchmarkHttpTreeMux_Route3000-4           	 3000000	       527 ns/op	     482 B/op	       3 allocs/op
PASS
ok  	github.com/marconi/golang-mux-benchmark	70.594s
```